### PR TITLE
🌟feat: Add local run logger with stats and import/export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,5 @@
-import { Button, HStack } from "@chakra-ui/react";
+import Home from "@/pages/Home";
 
-function App() {
-  return (
-    <HStack>
-      <Button>Click me</Button>
-      <Button>Click me</Button>
-    </HStack>
-  );
+export default function App() {
+  return <Home />;
 }
-
-export default App;

--- a/src/components/AddEditRunForm.tsx
+++ b/src/components/AddEditRunForm.tsx
@@ -101,7 +101,10 @@ export default function AddEditRunForm({ isOpen, onClose, initialRun }: Props) {
         </Box>
         <Box>
           <label>Distance (km)</label>
-          <Input type="number" step="0.01" value={distance} onChange={(e) => setDistance(parseFloat(e.target.value))} />
+          <Input type="number" step="0.01" value={distance} onChange={(e) => {
+            const val = parseFloat(e.target.value);
+            setDistance(isNaN(val) ? 0 : val);
+          }} />
         </Box>
         <Box>
           <label>Duration (hh:mm:ss)</label>

--- a/src/components/AddEditRunForm.tsx
+++ b/src/components/AddEditRunForm.tsx
@@ -67,7 +67,7 @@ export default function AddEditRunForm({ isOpen, onClose, initialRun }: Props) {
       notes,
     };
     if (isEdit && initialRun) {
-      updateRun({ ...runBase, id: initialRun.id, paceSecPerKm: 0 });
+      updateRun({ ...runBase, id: initialRun.id });
     } else {
       addRun(runBase);
     }

--- a/src/components/AddEditRunForm.tsx
+++ b/src/components/AddEditRunForm.tsx
@@ -1,0 +1,153 @@
+import { Box, Button, HStack, Input, Stack, Textarea } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { useRuns, type RunEntry, type RunType } from "@/store/runs";
+import { parseDuration, formatDuration, formatPace } from "@/lib/time";
+
+const typeOptions: RunType[] = [
+  "Easy",
+  "Tempo",
+  "Intervals",
+  "Hill",
+  "Long",
+  "Recovery",
+  "Strength",
+];
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  initialRun?: RunEntry;
+}
+
+export default function AddEditRunForm({ isOpen, onClose, initialRun }: Props) {
+  const { addRun, updateRun, deleteRun, duplicateRun } = useRuns();
+  const isEdit = !!initialRun;
+
+  const [date, setDate] = useState("");
+  const [distance, setDistance] = useState(0);
+  const [duration, setDuration] = useState("00:00:00");
+  const [type, setType] = useState<RunType>("Easy");
+  const [rpe, setRpe] = useState<number | undefined>();
+  const [tags, setTags] = useState("");
+  const [notes, setNotes] = useState("");
+
+  useEffect(() => {
+    if (initialRun) {
+      setDate(initialRun.date);
+      setDistance(initialRun.distanceKm);
+      setDuration(formatDuration(initialRun.durationSec));
+      setType(initialRun.type);
+      setRpe(initialRun.rpe);
+      setTags(initialRun.tags?.join(",") || "");
+      setNotes(initialRun.notes || "");
+    } else {
+      setDate(new Date().toISOString().slice(0, 10));
+      setDistance(0);
+      setDuration("00:00:00");
+      setType("Easy");
+      setRpe(undefined);
+      setTags("");
+      setNotes("");
+    }
+  }, [initialRun, isOpen]);
+
+  if (!isOpen) return null;
+
+  const durationSec = parseDuration(duration);
+  const pace = formatPace(distance > 0 ? durationSec / distance : 0);
+
+  const handleSave = () => {
+    const runBase = {
+      date,
+      distanceKm: distance,
+      durationSec,
+      type,
+      rpe,
+      tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
+      notes,
+    };
+    if (isEdit && initialRun) {
+      updateRun({ ...runBase, id: initialRun.id, paceSecPerKm: 0 });
+    } else {
+      addRun(runBase);
+    }
+    onClose();
+  };
+
+  const handleDelete = () => {
+    if (initialRun) {
+      deleteRun(initialRun.id);
+      onClose();
+    }
+  };
+
+  const handleDuplicate = () => {
+    if (initialRun) {
+      duplicateRun(initialRun.id);
+      onClose();
+    }
+  };
+
+  return (
+    <Box position="fixed" top={0} right={0} w={{ base: "100%", md: "400px" }} h="100%" bg="white" p={4} overflowY="auto" shadow="md" zIndex={10}>
+      <Stack gap={4}>
+        <HStack justify="space-between">
+          <strong>{isEdit ? "Edit Run" : "Add Run"}</strong>
+          <Button onClick={onClose}>Close</Button>
+        </HStack>
+        <Box>
+          <label>Date</label>
+          <Input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+        </Box>
+        <Box>
+          <label>Distance (km)</label>
+          <Input type="number" step="0.01" value={distance} onChange={(e) => setDistance(parseFloat(e.target.value))} />
+        </Box>
+        <Box>
+          <label>Duration (hh:mm:ss)</label>
+          <Input value={duration} onChange={(e) => setDuration(e.target.value)} />
+        </Box>
+        <Box>
+          <label>Pace (mm:ss/km)</label>
+          <Input value={pace} readOnly />
+        </Box>
+        <Box>
+          <label>Type</label>
+          <select value={type} onChange={(e) => setType(e.target.value as RunType)}>
+            {typeOptions.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </Box>
+        <Box>
+          <label>Effort (RPE 1-10)</label>
+          <input type="range" min={1} max={10} value={rpe ?? 5} onChange={(e) => setRpe(parseInt(e.target.value))} />
+        </Box>
+        <Box>
+          <label>Tags</label>
+          <Input value={tags} onChange={(e) => setTags(e.target.value)} />
+        </Box>
+        <Box>
+          <label>Notes</label>
+          <Textarea value={notes} onChange={(e) => setNotes(e.target.value)} />
+        </Box>
+        <HStack gap={3}>
+          {isEdit && initialRun && (
+            <Button colorScheme="red" onClick={handleDelete}>
+              Delete
+            </Button>
+          )}
+          {isEdit && initialRun && <Button onClick={handleDuplicate}>Duplicate</Button>}
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button colorScheme="blue" onClick={handleSave}>
+            {isEdit ? "Update" : "Save"}
+          </Button>
+        </HStack>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/FiltersBar.tsx
+++ b/src/components/FiltersBar.tsx
@@ -1,0 +1,87 @@
+import { HStack, Button, Box, Input } from "@chakra-ui/react";
+import type { RunType } from "@/store/runs";
+import { useState, useEffect } from "react";
+
+export interface Filters {
+  type?: RunType;
+  from?: string;
+  to?: string;
+  text?: string;
+}
+
+interface Props {
+  value: Filters;
+  onChange: (f: Filters) => void;
+  onClear: () => void;
+}
+
+const typeOptions: RunType[] = [
+  "Easy",
+  "Tempo",
+  "Intervals",
+  "Hill",
+  "Long",
+  "Recovery",
+  "Strength",
+];
+
+export default function FiltersBar({ value, onChange, onClear }: Props) {
+  const [state, setState] = useState<Filters>(value);
+  useEffect(() => setState(value), [value]);
+
+  const update = (patch: Partial<Filters>) => {
+    const next = { ...state, ...patch };
+    setState(next);
+    onChange(next);
+  };
+
+  return (
+    <HStack gap={4} flexWrap="wrap" mb={4}>
+      <Box>
+        <label>Type</label>
+        <select
+          value={state.type || ""}
+          onChange={(e) => update({ type: (e.target.value as RunType) || undefined })}
+        >
+          <option value="">All</option>
+          {typeOptions.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </Box>
+      <Box>
+        <label>From</label>
+        <Input
+          type="date"
+          value={state.from || ""}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            update({ from: e.target.value || undefined })
+          }
+        />
+      </Box>
+      <Box>
+        <label>To</label>
+        <Input
+          type="date"
+          value={state.to || ""}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            update({ to: e.target.value || undefined })
+          }
+        />
+      </Box>
+      <Box flex="1">
+        <label>Search</label>
+        <Input
+          placeholder="Tags or notes"
+          value={state.text || ""}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            update({ text: e.target.value || undefined })
+          }
+        />
+      </Box>
+      <Button onClick={onClear}>Clear</Button>
+    </HStack>
+  );
+}

--- a/src/components/RunsTable.tsx
+++ b/src/components/RunsTable.tsx
@@ -11,9 +11,9 @@ interface Props {
 
 export default function RunsTable({ runs, onEdit }: Props) {
   const { deleteRun, duplicateRun } = useRuns();
-  const [sort, setSort] = useState<{ key: "date" | "distance" | "duration"; dir: 1 } | null>(
-    null,
-  );
+  const [sort, setSort] = useState<
+    { key: "date" | "distance" | "duration"; dir: 1 | -1 }
+  >();
 
   const sorted = [...runs].sort((a, b) => {
     if (!sort) return 0;
@@ -33,7 +33,7 @@ export default function RunsTable({ runs, onEdit }: Props) {
   const toggleSort = (key: "date" | "distance" | "duration") => {
     setSort((s) => {
       if (!s || s.key !== key) return { key, dir: 1 };
-      return { key, dir: (s.dir === 1 ? -1 : 1) as 1 };
+      return { key, dir: s.dir === 1 ? -1 : 1 };
     });
   };
 

--- a/src/components/RunsTable.tsx
+++ b/src/components/RunsTable.tsx
@@ -1,0 +1,90 @@
+import { Box, Button, HStack } from "@chakra-ui/react";
+import type { RunEntry } from "@/store/runs";
+import { useRuns } from "@/store/runs";
+import { formatDuration, formatPace } from "@/lib/time";
+import { useState } from "react";
+
+interface Props {
+  runs: RunEntry[];
+  onEdit: (run: RunEntry) => void;
+}
+
+export default function RunsTable({ runs, onEdit }: Props) {
+  const { deleteRun, duplicateRun } = useRuns();
+  const [sort, setSort] = useState<{ key: "date" | "distance" | "duration"; dir: 1 } | null>(
+    null,
+  );
+
+  const sorted = [...runs].sort((a, b) => {
+    if (!sort) return 0;
+    const dir = sort.dir;
+    switch (sort.key) {
+      case "date":
+        return dir * a.date.localeCompare(b.date);
+      case "distance":
+        return dir * (a.distanceKm - b.distanceKm);
+      case "duration":
+        return dir * (a.durationSec - b.durationSec);
+      default:
+        return 0;
+    }
+  });
+
+  const toggleSort = (key: "date" | "distance" | "duration") => {
+    setSort((s) => {
+      if (!s || s.key !== key) return { key, dir: 1 };
+      return { key, dir: (s.dir === 1 ? -1 : 1) as 1 };
+    });
+  };
+
+  const header = (label: string, key: "date" | "distance" | "duration") => (
+    <th style={{ cursor: "pointer" }} onClick={() => toggleSort(key)}>
+      {label} {sort?.key === key ? (sort.dir === 1 ? "▲" : "▼") : ""}
+    </th>
+  );
+
+  return (
+    <Box overflowX="auto">
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            {header("Date", "date")}
+            {header("Distance (km)", "distance")}
+            {header("Duration", "duration")}
+            <th>Pace</th>
+            <th>Type</th>
+            <th>Effort</th>
+            <th>Tags</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((run) => (
+            <tr key={run.id}>
+              <td>{run.date}</td>
+              <td>{run.distanceKm.toFixed(2)}</td>
+              <td>{formatDuration(run.durationSec)}</td>
+              <td>{formatPace(run.paceSecPerKm)}</td>
+              <td>{run.type}</td>
+              <td>{run.rpe ?? ""}</td>
+              <td>{run.tags?.join(", ")}</td>
+              <td>
+                <HStack gap={1}>
+                  <Button size="xs" onClick={() => onEdit(run)}>
+                    Edit
+                  </Button>
+                  <Button size="xs" onClick={() => deleteRun(run.id)}>
+                    Delete
+                  </Button>
+                  <Button size="xs" onClick={() => duplicateRun(run.id)}>
+                    Duplicate
+                  </Button>
+                </HStack>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Box>
+  );
+}

--- a/src/components/StatsCards.tsx
+++ b/src/components/StatsCards.tsx
@@ -1,0 +1,51 @@
+import { SimpleGrid, Box } from "@chakra-ui/react";
+import type { RunEntry } from "@/store/runs";
+import { sumDistance, sumDuration, avgPace } from "@/lib/calc";
+import { formatDuration, formatPace } from "@/lib/time";
+
+interface Props {
+  runs: RunEntry[];
+}
+
+export default function StatsCards({ runs }: Props) {
+  const now = new Date();
+  const weekStart = new Date(now);
+  const diff = (weekStart.getDay() + 6) % 7;
+  weekStart.setDate(weekStart.getDate() - diff);
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+
+  const weekRuns = runs.filter((r) => new Date(r.date) >= weekStart);
+  const monthRuns = runs.filter((r) => new Date(r.date) >= monthStart);
+
+  const weekKm = sumDistance(weekRuns).toFixed(2);
+  const weekDur = formatDuration(sumDuration(weekRuns));
+  const weekPace = formatPace(avgPace(weekRuns));
+
+  const monthKm = sumDistance(monthRuns).toFixed(2);
+  const monthDur = formatDuration(sumDuration(monthRuns));
+  const monthPace = formatPace(avgPace(monthRuns));
+
+  const allKm = sumDistance(runs).toFixed(2);
+  const longest = Math.max(0, ...runs.map((r) => r.distanceKm)).toFixed(2);
+  const count = runs.length;
+
+  return (
+    <SimpleGrid columns={{ base: 1, md: 3 }} gap={4} mb={4}>
+      <Box borderWidth="1px" borderRadius="md" p={4}>
+        <strong>This Week</strong>
+        <br />
+        {weekKm} km / {weekDur} / {weekPace}
+      </Box>
+      <Box borderWidth="1px" borderRadius="md" p={4}>
+        <strong>This Month</strong>
+        <br />
+        {monthKm} km / {monthDur} / {monthPace}
+      </Box>
+      <Box borderWidth="1px" borderRadius="md" p={4}>
+        <strong>All Time</strong>
+        <br />
+        {allKm} km / longest {longest} km / {count} runs
+      </Box>
+    </SimpleGrid>
+  );
+}

--- a/src/lib/calc.ts
+++ b/src/lib/calc.ts
@@ -1,0 +1,49 @@
+import type { RunEntry } from "@/store/runs";
+
+export function calcPace(durationSec: number, distanceKm: number): number {
+  if (!distanceKm) return 0;
+  return durationSec / distanceKm;
+}
+
+export function sumDistance(runs: RunEntry[]): number {
+  return runs.reduce((acc, r) => acc + r.distanceKm, 0);
+}
+
+export function sumDuration(runs: RunEntry[]): number {
+  return runs.reduce((acc, r) => acc + r.durationSec, 0);
+}
+
+export function avgPace(runs: RunEntry[]): number {
+  const totalDistance = sumDistance(runs);
+  const totalDuration = sumDuration(runs);
+  return calcPace(totalDuration, totalDistance);
+}
+
+function isoWeek(date: Date): { year: number; week: number } {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return { year: d.getUTCFullYear(), week };
+}
+
+export function groupByWeek(runs: RunEntry[]): Record<string, RunEntry[]> {
+  return runs.reduce<Record<string, RunEntry[]>>((acc, run) => {
+    const { year, week } = isoWeek(new Date(run.date));
+    const key = `${year}-W${String(week).padStart(2, "0")}`;
+    acc[key] = acc[key] || [];
+    acc[key].push(run);
+    return acc;
+  }, {});
+}
+
+export function groupByMonth(runs: RunEntry[]): Record<string, RunEntry[]> {
+  return runs.reduce<Record<string, RunEntry[]>>((acc, run) => {
+    const d = new Date(run.date);
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    acc[key] = acc[key] || [];
+    acc[key].push(run);
+    return acc;
+  }, {});
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -13,14 +13,16 @@ export function loadDB(): RunDBV1 {
   return { version: 1, runs: [] };
 }
 
-let timeout: number | undefined;
-export function saveDB(db: RunDBV1) {
-  if (typeof localStorage === "undefined") return;
-  if (timeout) clearTimeout(timeout);
-  timeout = window.setTimeout(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(db));
-  }, 300);
-}
+export const saveDB = (() => {
+  let timeout: number | undefined;
+  return (db: RunDBV1) => {
+    if (typeof localStorage === "undefined") return;
+    if (timeout) clearTimeout(timeout);
+    timeout = window.setTimeout(() => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(db));
+    }, 300);
+  };
+})();
 
 export function resetDB() {
   if (typeof localStorage === "undefined") return;

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,28 @@
+import type { RunDBV1 } from "@/store/runs";
+
+const STORAGE_KEY = "runlogger.v1";
+
+export function loadDB(): RunDBV1 {
+  if (typeof localStorage === "undefined") return { version: 1, runs: [] };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw) as RunDBV1;
+  } catch {
+    /* ignore */
+  }
+  return { version: 1, runs: [] };
+}
+
+let timeout: number | undefined;
+export function saveDB(db: RunDBV1) {
+  if (typeof localStorage === "undefined") return;
+  if (timeout) clearTimeout(timeout);
+  timeout = window.setTimeout(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(db));
+  }, 300);
+}
+
+export function resetDB() {
+  if (typeof localStorage === "undefined") return;
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,20 @@
+export function parseDuration(value: string): number {
+  const parts = value.trim().split(":").map(Number);
+  if (parts.length !== 3 || parts.some(isNaN)) return 0;
+  const [h, m, s] = parts;
+  return h * 3600 + m * 60 + s;
+}
+
+export function formatDuration(totalSec: number): string {
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  return [h, m, s].map((n) => String(n).padStart(2, "0")).join(":");
+}
+
+export function formatPace(secPerKm: number): string {
+  if (!secPerKm) return "—";
+  const m = Math.floor(secPerKm / 60);
+  const s = Math.round(secPerKm % 60);
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,16 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Provider } from "@/components/ui/provider";
+import { RunsProvider } from "@/store/runs";
 
 import App from "./App.tsx";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <Provider>
-      <App />
+      <RunsProvider>
+        <App />
+      </RunsProvider>
     </Provider>
   </StrictMode>
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -87,10 +87,10 @@ export default function Home() {
           setPendingImport(data);
           importDialog.onOpen();
         } else {
-          alert("Invalid file");
+          alert("File structure is incorrect or missing required fields.");
         }
       } catch {
-        alert("Invalid file");
+        alert("File is not valid JSON.");
       }
     });
   };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,136 @@
+import { useState, useRef } from "react";
+import {
+  Box,
+  Button,
+  HStack,
+  VStack,
+  useDisclosure,
+  Input,
+} from "@chakra-ui/react";
+import { useRuns, type RunEntry } from "@/store/runs";
+import AddEditRunForm from "@/components/AddEditRunForm";
+import FiltersBar, { type Filters } from "@/components/FiltersBar";
+import RunsTable from "@/components/RunsTable";
+import StatsCards from "@/components/StatsCards";
+
+export default function Home() {
+  const { runs, importRuns, reset } = useRuns();
+  const { open: isOpen, onOpen, onClose } = useDisclosure();
+  const [editing, setEditing] = useState<RunEntry | null>(null);
+  const [filters, setFilters] = useState<Filters>({});
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const filtered = runs.filter((r) => {
+    if (filters.type && r.type !== filters.type) return false;
+    if (filters.from && r.date < filters.from) return false;
+    if (filters.to && r.date > filters.to) return false;
+    if (filters.text) {
+      const t = filters.text.toLowerCase();
+      const tags = r.tags?.join(",").toLowerCase() || "";
+      const notes = r.notes?.toLowerCase() || "";
+      if (!tags.includes(t) && !notes.includes(t)) return false;
+    }
+    return true;
+  });
+
+  const openNew = () => {
+    setEditing(null);
+    onOpen();
+  };
+
+  const openEdit = (run: RunEntry) => {
+    setEditing(run);
+    onOpen();
+  };
+
+  const exportJSON = () => {
+    const blob = new Blob([JSON.stringify({ version: 1, runs }, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "runs.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportCSV = () => {
+    const header = "date,distance_km,duration_sec,pace_sec_per_km,type,rpe,tags,notes";
+    const rows = runs.map((r) =>
+      [
+        r.date,
+        r.distanceKm,
+        r.durationSec,
+        r.paceSecPerKm,
+        r.type,
+        r.rpe ?? "",
+        r.tags?.join("|") ?? "",
+        r.notes ?? "",
+      ].join(","),
+    );
+    const blob = new Blob([header + "\n" + rows.join("\n")], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "runs.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    file.text().then((text) => {
+      try {
+        const data = JSON.parse(text);
+        if (data.version === 1 && Array.isArray(data.runs)) {
+          const mode = window.confirm("Replace existing data? Click OK to replace, Cancel to merge")
+            ? "replace"
+            : "merge";
+          importRuns(data, mode);
+        } else {
+          alert("Invalid file");
+        }
+      } catch {
+        alert("Invalid file");
+      }
+    });
+  };
+
+  const triggerImport = () => fileRef.current?.click();
+
+  const handleReset = () => {
+    if (window.confirm("Reset all data?")) reset();
+  };
+
+  return (
+    <VStack align="stretch" gap={4} p={4}>
+      <HStack justify="space-between" gap={4}>
+        <HStack gap={2}>
+          <Box fontWeight="bold">Run Logger</Box>
+          <Button colorScheme="blue" onClick={openNew}>
+            Add Run
+          </Button>
+        </HStack>
+        <HStack gap={2}>
+          <Button onClick={exportCSV}>Export CSV</Button>
+          <Button onClick={exportJSON}>Export JSON</Button>
+          <Button onClick={triggerImport}>Import JSON</Button>
+          <Button onClick={handleReset}>Reset Data</Button>
+        </HStack>
+        <Input
+          type="file"
+          accept="application/json"
+          ref={fileRef}
+          display="none"
+          onChange={handleImport}
+        />
+      </HStack>
+      <StatsCards runs={runs} />
+      <FiltersBar value={filters} onChange={setFilters} onClear={() => setFilters({})} />
+      <RunsTable runs={filtered} onEdit={openEdit} />
+      <AddEditRunForm isOpen={isOpen} onClose={onClose} initialRun={editing || undefined} />
+    </VStack>
+  );
+}

--- a/src/store/runs.tsx
+++ b/src/store/runs.tsx
@@ -32,7 +32,7 @@ export interface RunDBV1 {
 interface RunsContextValue {
   runs: RunEntry[];
   addRun: (run: Omit<RunEntry, "id" | "paceSecPerKm">) => void;
-  updateRun: (run: RunEntry) => void;
+  updateRun: (run: Omit<RunEntry, "paceSecPerKm">) => void;
   deleteRun: (id: string) => void;
   duplicateRun: (id: string) => void;
   importRuns: (data: RunDBV1, mode: "merge" | "replace") => void;

--- a/src/store/runs.tsx
+++ b/src/store/runs.tsx
@@ -1,0 +1,93 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useState } from "react";
+import { loadDB, saveDB, resetDB } from "@/lib/storage";
+import { calcPace } from "@/lib/calc";
+
+export type RunType =
+  | "Easy"
+  | "Tempo"
+  | "Intervals"
+  | "Hill"
+  | "Long"
+  | "Recovery"
+  | "Strength";
+
+export interface RunEntry {
+  id: string;
+  date: string; // YYYY-MM-DD
+  distanceKm: number; // 0 for Strength
+  durationSec: number; // 0 allowed for Strength
+  paceSecPerKm: number; // derived; 0 if distance==0
+  type: RunType;
+  rpe?: number; // 1..10
+  tags?: string[];
+  notes?: string;
+}
+
+export interface RunDBV1 {
+  version: 1;
+  runs: RunEntry[];
+}
+
+interface RunsContextValue {
+  runs: RunEntry[];
+  addRun: (run: Omit<RunEntry, "id" | "paceSecPerKm">) => void;
+  updateRun: (run: RunEntry) => void;
+  deleteRun: (id: string) => void;
+  duplicateRun: (id: string) => void;
+  importRuns: (data: RunDBV1, mode: "merge" | "replace") => void;
+  reset: () => void;
+}
+
+const RunsContext = createContext<RunsContextValue | undefined>(undefined);
+
+export function RunsProvider({ children }: { children: React.ReactNode }) {
+  const [runs, setRuns] = useState<RunEntry[]>(() => loadDB().runs);
+
+  useEffect(() => {
+    saveDB({ version: 1, runs });
+  }, [runs]);
+
+  const addRun: RunsContextValue["addRun"] = (run) => {
+    const paceSecPerKm = calcPace(run.durationSec, run.distanceKm);
+    setRuns((r) => [...r, { ...run, id: crypto.randomUUID(), paceSecPerKm }]);
+  };
+
+  const updateRun: RunsContextValue["updateRun"] = (run) => {
+    setRuns((r) => r.map((x) => (x.id === run.id ? { ...run, paceSecPerKm: calcPace(run.durationSec, run.distanceKm) } : x)));
+  };
+
+  const deleteRun = (id: string) => setRuns((r) => r.filter((x) => x.id !== id));
+
+  const duplicateRun = (id: string) => {
+    const orig = runs.find((r) => r.id === id);
+    if (orig) {
+      const copy = { ...orig, id: crypto.randomUUID() };
+      setRuns((r) => [...r, copy]);
+    }
+  };
+
+  const importRuns = (data: RunDBV1, mode: "merge" | "replace") => {
+    if (mode === "replace") setRuns(data.runs);
+    else setRuns((r) => [...r, ...data.runs]);
+  };
+
+  const reset = () => {
+    resetDB();
+    setRuns([]);
+  };
+
+  return (
+    <RunsContext.Provider
+      value={{ runs, addRun, updateRun, deleteRun, duplicateRun, importRuns, reset }}
+    >
+      {children}
+    </RunsContext.Provider>
+  );
+}
+
+export function useRuns() {
+  const ctx = useContext(RunsContext);
+  if (!ctx) throw new Error("RunsProvider missing");
+  return ctx;
+}

--- a/src/store/runs.tsx
+++ b/src/store/runs.tsx
@@ -69,7 +69,11 @@ export function RunsProvider({ children }: { children: React.ReactNode }) {
 
   const importRuns = (data: RunDBV1, mode: "merge" | "replace") => {
     if (mode === "replace") setRuns(data.runs);
-    else setRuns((r) => [...r, ...data.runs]);
+    else setRuns((r) => {
+      const existingIds = new Set(r.map(run => run.id));
+      const filteredRuns = data.runs.filter(run => !existingIds.has(run.id));
+      return [...r, ...filteredRuns];
+    });
   };
 
   const reset = () => {


### PR DESCRIPTION
## Summary
- implement run storage context with localStorage persistence
- add run form, table, filters, and stats cards
- support CSV/JSON export and JSON import/reset

## Testing
- `bunx eslint src/pages/Home.tsx src/components/AddEditRunForm.tsx src/components/FiltersBar.tsx src/components/RunsTable.tsx src/components/StatsCards.tsx src/lib/time.ts src/lib/calc.ts src/lib/storage.ts src/store/runs.tsx src/App.tsx src/main.tsx`
- `bun run build`
- `bun run test` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cd30a52883228113c69500ad9c48